### PR TITLE
Make child objects inherit parent's extension methods

### DIFF
--- a/src/Traits/HandlesExtensionMethods.php
+++ b/src/Traits/HandlesExtensionMethods.php
@@ -4,6 +4,7 @@ namespace NorseBlue\ExtensibleObjects\Traits;
 
 use BadMethodCallException;
 use Closure;
+use NorseBlue\ExtensibleObjects\Contracts\Extensible;
 use NorseBlue\ExtensibleObjects\Contracts\ExtensionMethod;
 use NorseBlue\ExtensibleObjects\Exceptions\ClassNotExtensionMethod;
 use NorseBlue\ExtensibleObjects\Exceptions\ExtensionNotCallableException;
@@ -59,22 +60,50 @@ trait HandlesExtensionMethods
      * Check if the extension is registered.
      *
      * @param string $name The name of the extension method.
+     * @param bool $exclude_parent If true, excludes parent extension methods
      *
-     * @return bool True if the extension is registered, false otherwise.
+     * @return bool true if the extension is registered, false otherwise.
      */
-    public static function hasExtensionMethod(string $name): bool
+    public static function hasExtensionMethod(string $name, bool $exclude_parent = false): bool
     {
-        return isset(static::$extensions[$name]);
+        if (isset(static::$extensions[$name])) {
+            return true;
+        }
+
+        return ($exclude_parent) ? false : isset(static::getParentExtensionMethods()[$name]);
     }
 
     /**
      * Get the registered extension methods.
      *
+     * @param bool $exclude_parent If true, excludes parent extension methods
+     *
      * @return callable[]
      */
-    public static function getExtensionMethods(): array
+    public static function getExtensionMethods(bool $exclude_parent = false): array
     {
-        return static::$extensions;
+        $base_extensions = [];
+        if (!$exclude_parent) {
+            $base_extensions = static::getParentExtensionMethods();
+        }
+
+        return array_merge($base_extensions, static::$extensions);
+    }
+
+    /**
+     * Get the parent extension methods.
+     *
+     * @return callable[]
+     */
+    public static function getParentExtensionMethods(): array
+    {
+        $parent = get_parent_class(static::class);
+        if ($parent === false || !is_subclass_of($parent, Extensible::class)) {
+            return [];
+        }
+
+        /** @var Extensible $parent */
+        return $parent::getExtensionMethods();
     }
 
     //region Magic Methods =====

--- a/src/Traits/HandlesExtensionMethods.php
+++ b/src/Traits/HandlesExtensionMethods.php
@@ -10,9 +10,7 @@ use NorseBlue\ExtensibleObjects\Exceptions\ExtensionNotCallableException;
 
 trait HandlesExtensionMethods
 {
-    /**
-     * @var callable[] The registered extensions.
-     */
+    /** @var callable[] The registered extensions. */
     protected static $extensions = [];
 
     /**
@@ -94,7 +92,9 @@ trait HandlesExtensionMethods
     public function __call(string $name, $parameters)
     {
         if (!static::hasExtensionMethod($name)) {
-            throw new BadMethodCallException(sprintf('Extension method %s::%s does not exist.', static::class, $name));
+            throw new BadMethodCallException(
+                sprintf('Extension method %s::%s does not exist.', static::class, $name)
+            );
         }
 
         $callable = static::$extensions[$name];

--- a/tests/Helpers/ChildExtensionMethodReplacement.php
+++ b/tests/Helpers/ChildExtensionMethodReplacement.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace NorseBlue\ExtensibleObjects\Tests\Helpers;
+
+use NorseBlue\ExtensibleObjects\Contracts\ExtensionMethod;
+
+/**
+ * Class ChildExtensionMethodReplacement
+ *
+ * @package NorseBlue\ExtensibleObjects\Tests\Helpers
+ *
+ * @extends ChildObject
+ */
+class ChildExtensionMethodReplacement extends SimpleObject implements ExtensionMethod
+{
+    /**
+     * @return callable(int $operand)
+     */
+    public function __invoke(): callable
+    {
+        /**
+         * Subtract the given operand from the protected value.
+         *
+         * @param int $operand
+         *
+         * @return int
+         */
+        return function (int $operand): int {
+            return $this->protected_value - $operand;
+        };
+    }
+}

--- a/tests/Helpers/ChildObject.php
+++ b/tests/Helpers/ChildObject.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace NorseBlue\ExtensibleObjects\Tests\Helpers;
+
+class ChildObject extends SimpleObject
+{
+    /**  @var callable[] The registered extensions. */
+    protected static $extensions = [];
+}

--- a/tests/Helpers/DynamicMethodUsingPrivateValue.php
+++ b/tests/Helpers/DynamicMethodUsingPrivateValue.php
@@ -9,7 +9,6 @@ use NorseBlue\ExtensibleObjects\Contracts\ExtensionMethod;
  *
  * @package NorseBlue\ExtensibleObjects\Tests\Helpers
  *
- * @method int add_to_private(int $operand) Through DynamicMethodUsingPrivateValue extension method.
  * @extends SimpleObject
  */
 class DynamicMethodUsingPrivateValue extends SimpleObject implements ExtensionMethod

--- a/tests/Helpers/DynamicMethodUsingProtectedValue.php
+++ b/tests/Helpers/DynamicMethodUsingProtectedValue.php
@@ -9,7 +9,6 @@ use NorseBlue\ExtensibleObjects\Contracts\ExtensionMethod;
  *
  * @package NorseBlue\ExtensibleObjects\Tests\Helpers
  *
- * @method int subtract_from_protected(int $operand) Through DynamicMethodUsingProtectedValue extension method.
  * @extends SimpleObject
  */
 class DynamicMethodUsingProtectedValue extends SimpleObject implements ExtensionMethod

--- a/tests/Unit/ExtensionMethodTest.php
+++ b/tests/Unit/ExtensionMethodTest.php
@@ -6,6 +6,8 @@ use BadMethodCallException;
 use Exception;
 use NorseBlue\ExtensibleObjects\Exceptions\ClassNotExtensionMethod;
 use NorseBlue\ExtensibleObjects\Exceptions\ExtensionNotCallableException;
+use NorseBlue\ExtensibleObjects\Tests\Helpers\ChildExtensionMethodReplacement;
+use NorseBlue\ExtensibleObjects\Tests\Helpers\ChildObject;
 use NorseBlue\ExtensibleObjects\Tests\Helpers\DynamicMethodUsingPrivateValue;
 use NorseBlue\ExtensibleObjects\Tests\Helpers\DynamicMethodUsingProtectedValue;
 use NorseBlue\ExtensibleObjects\Tests\Helpers\FooObject;
@@ -18,12 +20,14 @@ class ExtensionMethodTest extends TestCase
     {
         SimpleObject::registerExtensionMethod('add_to_private', DynamicMethodUsingPrivateValue::class);
         SimpleObject::registerExtensionMethod('subtract_from_protected', DynamicMethodUsingProtectedValue::class);
+        ChildObject::registerExtensionMethod('subtract_from_protected', ChildExtensionMethodReplacement::class);
     }
 
     protected function tearDown(): void
     {
         SimpleObject::unregisterExtensionMethod('add_to_private');
         SimpleObject::unregisterExtensionMethod('subtract_from_protected');
+        ChildObject::unregisterExtensionMethod('subtract_from_protected');
     }
 
 
@@ -102,5 +106,29 @@ class ExtensionMethodTest extends TestCase
         }
 
         $this->fail(BadMethodCallException::class . ' was not thrown.');
+    }
+
+    /** @test */
+    public function child_object_inherits_parent_extension_methods()
+    {
+        $this->assertTrue(ChildObject::hasExtensionMethod('add_to_private'));
+        $this->assertFalse(ChildObject::hasExtensionMethod('add_to_private', true));
+        $this->assertTrue(ChildObject::hasExtensionMethod('subtract_from_protected'));
+
+        $extensions = ChildObject::getExtensionMethods();
+        $extensions_excluding_parent = ChildObject::getExtensionMethods(true);
+        $parent_extensions = ChildObject::getParentExtensionMethods();
+
+        $this->assertCount(2, $extensions);
+        $this->assertCount(1, $extensions_excluding_parent);
+        $this->assertCount(2, $parent_extensions);
+
+        $this->assertInstanceOf(DynamicMethodUsingPrivateValue::class, $extensions['add_to_private']);
+        $this->assertInstanceOf(ChildExtensionMethodReplacement::class, $extensions['subtract_from_protected']);
+
+        $this->assertInstanceOf(ChildExtensionMethodReplacement::class, $extensions_excluding_parent['subtract_from_protected']);
+
+        $this->assertInstanceOf(DynamicMethodUsingPrivateValue::class, $parent_extensions['add_to_private']);
+        $this->assertInstanceOf(DynamicMethodUsingProtectedValue::class, $parent_extensions['subtract_from_protected']);
     }
 }


### PR DESCRIPTION
Previously child object had to re-register parent extension methods if they wanted to use them.

With this changes, parent's registered extension methods are available to child objects automatically and are called if the child object does not replace the extension method with its own.